### PR TITLE
Add repos synchronization tool

### DIFF
--- a/tools/gitee_repo_sync.sh
+++ b/tools/gitee_repo_sync.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+repos=`curl https://api.github.com/orgs/kunpengcompute/repos | jq '.[] | .name' |  sed 's/"//g'`
+github_org=kunpengcompute
+gitee_org=kunpengcompute
+
+function clone_and_cd_repo
+{
+  echo -e "\033[31m(0/3)\033[0m" "Downloading..."
+  if [ ! -d "$2" ]; then
+    git clone https://github.com/$1/$2.git
+    cd $2
+    git remote add gitee git@gitee.com:$gitee_org/$2.git
+  else
+    cd $2
+  fi
+}
+
+function update_repo
+{
+  echo -e "\033[31m(1/3)\033[0m" "Updating..."
+  git pull -p
+}
+
+function import_repo
+{
+  echo -e "\033[31m(2/3)\033[0m" "Importing..."
+  git remote set-head origin -d
+  git push gitee refs/remotes/origin/*:refs/heads/* --tags --prune
+}
+
+for repo in $repos
+{
+  echo -e "\n\033[31mBackup $repo ...\033[0m"
+
+  clone_and_cd_repo $github_org $repo
+
+  update_repo
+
+  if [ $? -eq 0 ]; then
+    import_repo
+  else
+    echo -e "\033[31mUpdate failed.\033[0m" ""
+  fi
+
+  cd ..
+}


### PR DESCRIPTION
We need a tool to do the synchronization from github to gitee, and then use this tool to do the auto-sync periodically.

This patch add a script will fetch all repos from github, and then push them (include commits, branch, tags) to gitee mirror repo.

Close: #2 