### PR TITLE
Add cache support

### DIFF
--- a/.github/workflows/gitee-repos-mirror.yml
+++ b/.github/workflows/gitee-repos-mirror.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: /home/runner/work/Kunpeng/Kunpeng/kunpeng-cache
-        key: ${{ runner.os }}-openeuler-repos-cache
+        key: ${{ runner.os }}-kunpeng-repos-cache
 
     - name: Mirror the Github organization repos to Gitee.
       uses: Yikun/hub-mirror-action@v0.05

--- a/.github/workflows/gitee-repos-mirror.yml
+++ b/.github/workflows/gitee-repos-mirror.yml
@@ -1,6 +1,9 @@
 name: Gitee repos mirror periodic job
 
 on:
+  pull_request:
+    # Runs at every pull requests submitted in master branch 
+    branches: [ master ]
   schedule:
     # Runs at 01:00 UTC (9:00 AM Beijing) every day
     - cron:  '0 1 * * *'
@@ -11,11 +14,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Cache src repos
+      uses: actions/cache@v1
+      with:
+        path: /home/runner/work/hub-mirror-action/hub-mirror-action/kunpeng-cache
+        key: ${{ runner.os }}-openeuler-repos-cache
+
     - name: Mirror the Github organization repos to Gitee.
-      uses: Yikun/hub-mirror-action@v0.03
+      uses: Yikun/hub-mirror-action@v0.05
       with:
         src: github/kunpengcompute
         dst: gitee/kunpengcompute
         dst_key: ${{ secrets.GITEE_PRIVATE_KEY }}
         dst_token:  ${{ secrets.GITEE_TOKEN }}
         account_type: org
+        cache_path: /github/workspace/kunpeng-cache

--- a/.github/workflows/gitee-repos-mirror.yml
+++ b/.github/workflows/gitee-repos-mirror.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Cache src repos
+    - name: Cache kunpengcompute src repos
       uses: actions/cache@v1
       with:
         path: /home/runner/work/Kunpeng/Kunpeng/kunpeng-cache

--- a/.github/workflows/gitee-repos-mirror.yml
+++ b/.github/workflows/gitee-repos-mirror.yml
@@ -2,6 +2,8 @@ name: Gitee repos mirror periodic job
 
 on:
   pull_request:
+    paths:
+    - '.github/workflows/**'
     # Runs at every pull requests submitted in master branch 
     branches: [ master ]
   schedule:

--- a/.github/workflows/gitee-repos-mirror.yml
+++ b/.github/workflows/gitee-repos-mirror.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Cache src repos
       uses: actions/cache@v1
       with:
-        path: /home/runner/work/hub-mirror-action/hub-mirror-action/kunpeng-cache
+        path: /home/runner/work/Kunpeng/Kunpeng/kunpeng-cache
         key: ${{ runner.os }}-openeuler-repos-cache
 
     - name: Mirror the Github organization repos to Gitee.


### PR DESCRIPTION
This patch add the cache support for kunpeng to speed up the mirror. All src repos will stored in `/github/workspace/kunpeng-cache`, and action/cache will help save and store the cache.

Note that `/home/runner/work/Kunpeng/Kunpeng/kunpeng-cache` is the action host path, and `/github/workspace/kunpeng-cache` is the action container path.